### PR TITLE
feat(website): add basic Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:carbon
+
+COPY . /data
+
+WORKDIR /data
+
+RUN npm install
+
+CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.PHONY: all build start stop restart logs
+
+APPNAME     := website
+VERSION     := 1.0.0
+TEAM        := tourainetech
+IMAGE       := $(TEAM)/$(APPNAME):$(VERSION)
+
+#Usefull in remote Docker host management
+#DOCKER_HOST ?= tcp://127.0.0.1:2375
+#DOCKER_CMD  := $(DOCKER_BIN) -H $(DOCKER_HOST)
+DOCKER_BIN  ?= docker
+WORKSPACE   ?= .
+DOCKER_CMD = $(DOCKER_BIN)
+
+
+NO_COLOR=\033[33;0m
+OK_COLOR=\033[33;32m
+ERR_COLOR=\033[33;31m
+INFO_COLOR=\033[33;01m
+
+all: build checkdb start
+
+build:
+	@echo "$(INFO_COLOR)Building $(IMAGE)...$(NO_COLOR)"
+	$(DOCKER_CMD) build --rm -t $(IMAGE) $(WORKSPACE)
+	@echo "$(OK_COLOR)Building $(IMAGE): Done$(NO_COLOR)"
+
+sync:
+	@echo "$(INFO_COLOR)Synchronizing node_modules$(NO_COLOR)"
+	$(DOCKER_CMD) cp $(APPNAME):/data/node_modules .
+	@echo "$(OK_COLOR)Sync with $(APPNAME): Done$(NO_COLOR)"
+
+start:
+	@echo "$(INFO_COLOR)Starting $(IMAGE)...$(NO_COLOR)"
+	$(DOCKER_CMD) run $(docker_run_flags) \
+				-d -p 4000:4000 \
+				--name $(APPNAME) $(IMAGE) npm start
+	@echo "$(OK_COLOR)Starting $(IMAGE): Done$(NO_COLOR)"
+
+stop:
+	@echo "$(INFO_COLOR)Stopping $(IMAGE)...$(NO_COLOR)"
+	-$(DOCKER_CMD) rm -f $(APPNAME)
+	@echo "$(OK_COLOR)Stopping $(IMAGE): Done$(NO_COLOR)"
+
+restart: stop start
+
+logs:
+	$(DOCKER_CMD) logs -f $(APPNAME)
+
+dev:
+	$(eval docker_run_flags += -v $(PWD):/data)
+
+install: dev
+	$(DOCKER_CMD) run --rm $(docker_run_flags) $(IMAGE) npm install

--- a/README.md
+++ b/README.md
@@ -11,3 +11,22 @@ To have a local live version use : `npm start`
 file ending by print.scss are imported via a link for print only
 
 Each pull requests are built and deployed on github pages.
+
+## Using Docker
+
+It just run the webpack-dev-server inside Docker... **NOT FOR PROD**
+
+
+`make build` will create the project related Docker image
+
+`make start` will start the web
+
+Then visit [localhost:4000](http://localhost:4000)
+
+`stop` and `restart` are available
+
+### Docker for dev
+
+Once image have been built and run you can use `make sync` to get downloaded *node_modules*.
+
+After stopping the standalone container you can use `make dev start` to use your local filesystem instead of the image one.

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -126,6 +126,7 @@ module.exports = {
         inline     : true,
         compress   : true,
         contentBase: dist,
+        host: '0.0.0.0',
         port       : 4000,
         open       : true,
         overlay    : true,


### PR DESCRIPTION
Let someone run the website using docker.

It just run the webpack-dev-server inside Docker... NOT FOR PROD
